### PR TITLE
Improved site.py over .python_history handling

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -448,7 +448,16 @@ def enablerlcompleter():
                     # home directory does not exist or is not writable
                     # https://bugs.python.org/issue19891
                     pass
-
+                except OSError:
+                    if sys.platform == "linux" and not os.access(history, os.W_OK):
+                        if os.getuid() == 0:
+                            chattrcmd = "chattr -i " + history
+                            os.system(chattrcmd)
+                        else
+                            chattrmsg = "Permission error!, try running 'chattr -i " + history + "'"
+                            print(chattrmsg)
+                    else
+                        print("An error occured while writing to .python_history")
             atexit.register(write_history)
 
     sys.__interactivehook__ = register_readline


### PR DESCRIPTION
Added Linux-specific code to site.py for better handling of writing permission errors on the .python_history file.
